### PR TITLE
Use std::is_trivially_destructible instead of std::has_trivial_destructor

### DIFF
--- a/optional.hpp
+++ b/optional.hpp
@@ -283,7 +283,7 @@ struct constexpr_optional_base
 
 template <class T> 
 using OptionalBase = typename std::conditional<
-    std::has_trivial_destructor<T>::value, 
+    std::is_trivially_destructible<T>::value, 
     constexpr_optional_base<T>,
     optional_base<T>
 >::type;


### PR DESCRIPTION
`std::has_trivial_destructor` is from a draft of the standard; the final version uses `std::is_trivially_destructible` instead.  GCC 4.8 supports only `std::is_trivially_destructible`.  I'm not sure about Clang.

This commit changes `std::has_trivial_destructor` to `std::is_trivially_destructible`.  If Clang doesn't support `std::is_trivially_destructible` then I suppose some ifdefs will be needed, but unfortunately I don't have access to Clang to test this.
