### PR TITLE
qualified call to new and cast placement param to void* to ensure placement new

### DIFF
--- a/optional.hpp
+++ b/optional.hpp
@@ -377,7 +377,7 @@ class optional : private OptionalBase<T>
   void initialize(Args&&... args) noexcept(noexcept(T(std::forward<Args>(args)...)))
   {
     assert(!OptionalBase<T>::init_);
-    new (dataptr()) T(std::forward<Args>(args)...);
+    ::new ((void*)dataptr()) T(std::forward<Args>(args)...);
     OptionalBase<T>::init_ = true;
   }
 
@@ -385,7 +385,7 @@ class optional : private OptionalBase<T>
   void initialize(std::initializer_list<U> il, Args&&... args) noexcept(noexcept(T(il, std::forward<Args>(args)...)))
   {
     assert(!OptionalBase<T>::init_);
-    new (dataptr()) T(il, std::forward<Args>(args)...);
+    ::new ((void*)dataptr()) T(il, std::forward<Args>(args)...);
     OptionalBase<T>::init_ = true;
   }
 
@@ -399,13 +399,13 @@ public:
   optional(const optional& rhs) 
   : OptionalBase<T>(only_set_initialized, rhs.initialized())
   {
-    if (rhs.initialized()) new (dataptr()) T(*rhs);
+    if (rhs.initialized()) ::new ((void*)dataptr()) T(*rhs);
   }
 
   optional(optional&& rhs) noexcept(std::is_nothrow_move_constructible<T>::value)
   : OptionalBase<T>(only_set_initialized, rhs.initialized())
   {
-    if (rhs.initialized()) new (dataptr()) T(std::move(*rhs));
+    if (rhs.initialized()) ::new ((void*)dataptr()) T(std::move(*rhs));
   }
 
   constexpr optional(const T& v) : OptionalBase<T>(v) {}


### PR DESCRIPTION
I may be mistaken, but it would seem that placement new is desired.  The changes made in this pull request are suggested by STL to ensure placement new is called and not an overload.
http://www.reddit.com/r/cpp/comments/1tedni/notsocommon_pitfalls_of_c_xpost_rcplusplus/ce7bqnu
