### PR TITLE
Add support for MSVC 2015

### DIFF
--- a/optional.hpp
+++ b/optional.hpp
@@ -55,6 +55,12 @@
 #   endif
 # endif
 
+# if defined _MSC_VER
+#   if (_MSC_VER >= 1900)
+#     define TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#   endif
+# endif
+
 # if defined __clang__
 #   if (__clang_major__ > 2) || (__clang_major__ == 2) && (__clang_minor__ >= 9)
 #     define OPTIONAL_HAS_THIS_RVALUE_REFS 1
@@ -63,10 +69,11 @@
 #   endif
 # elif defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
 #   define OPTIONAL_HAS_THIS_RVALUE_REFS 1
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+#   define OPTIONAL_HAS_THIS_RVALUE_REFS 1
 # else
 #   define OPTIONAL_HAS_THIS_RVALUE_REFS 0
 # endif 
-
 
 # if defined TR2_OPTIONAL_GCC_4_8_1_AND_HIGHER___
 #   define OPTIONAL_HAS_CONSTEXPR_INIT_LIST 1
@@ -98,6 +105,8 @@ namespace experimental{
     // leave it: it is already there
 # elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
     // leave it: it is already there
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+    // leave it: it is already there
 # elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
     // leave it: the user doesn't want it
 # else
@@ -110,6 +119,8 @@ namespace experimental{
     // leave it; our metafunctions are already defined.
 # elif defined TR2_OPTIONAL_CLANG_3_4_2_AND_HIGHER_
     // leave it; our metafunctions are already defined.
+# elif defined TR2_OPTIONAL_MSVC_2015_AND_HIGHER___
+    // leave it: it is already there
 # elif defined TR2_OPTIONAL_DISABLE_EMULATION_OF_TYPE_TRAITS
     // leave it: the user doesn't want it
 # else
@@ -187,17 +198,7 @@ template <class T> inline constexpr typename std::remove_reference<T>::type&& co
 #if defined NDEBUG
 # define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
 #else
-# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : (fail(#CHECK, __FILE__, __LINE__), (EXPR)))
-  inline void fail(const char* expr, const char* file, unsigned line)
-  {
-  # if defined __clang__ || defined __GNU_LIBRARY__
-    __assert(expr, file, line);
-  # elif defined __GNUC__
-    _assert(expr, file, line);
-  # else
-  #   error UNSUPPORTED COMPILER
-  # endif
-  }
+# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert(!#CHECK);}(), (EXPR)))
 #endif
 
 
@@ -255,7 +256,7 @@ struct nullopt_t
   struct init{};
   constexpr nullopt_t(init){}
 }; 
-constexpr nullopt_t nullopt{nullopt_t::init{}};
+constexpr nullopt_t nullopt{nullopt_t::init()};
 
 
 // 20.5.8, class bad_optional_access


### PR DESCRIPTION
This adds support for Visual Studio 2015:
- Don't redefine type traits, since they're implemented in VS2015's stdlib
- Change ASSERTED_EXPRESSION macro to be compiler-agnostic
- Work around a constexpr initialization bug in the VS2015 beta