### PR TITLE
fix moving from optional<const T>

### DIFF
--- a/optional.hpp
+++ b/optional.hpp
@@ -341,8 +341,8 @@ struct constexpr_optional_base
 template <class T>
 using OptionalBase = typename std::conditional<
     is_trivially_destructible<T>::value,
-    constexpr_optional_base<T>,
-    optional_base<T>
+    constexpr_optional_base<typename std::remove_const<T>::type>,
+    optional_base<typename std::remove_const<T>::type>
 >::type;
 
 
@@ -355,7 +355,7 @@ class optional : private OptionalBase<T>
   
 
   constexpr bool initialized() const noexcept { return OptionalBase<T>::init_; }
-  T* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
+  typename std::remove_const<T>::type* dataptr() {  return std::addressof(OptionalBase<T>::storage_.value_); }
   constexpr const T* dataptr() const { return detail_::static_addressof(OptionalBase<T>::storage_.value_); }
   
 # if OPTIONAL_HAS_THIS_RVALUE_REFS == 1


### PR DESCRIPTION
There is nothing criminal in moving from optional<const T>, though the code below won't compile
```cpp
auto test() -> std::experimental::optional<const int> {
    return {1};
}
int main() {
    auto t = test();
}
```
clang says:
```
$ clang++ -std=c++11 main.cpp 
In file included from main.cpp:1:
./optional.hpp:416:16: error: static_cast from 'const int *' to 'void *' is not allowed
        ::new (static_cast<void*>(dataptr())) T(std::move(*rhs));
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
main.cpp:8:14: note: in instantiation of member function 'std::experimental::optional<const int>::optional' requested here
    auto t = test();
             ^
1 error generated.
```

I consider adding a `const_cast` to placement new not a good option. Holding a never const type in the `OptionalBase` seems a valid one.