### PR TITLE
Fix include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 if(NOT (CMAKE_VERSION VERSION_LESS 3.0))
     add_library(optional INTERFACE)
     target_include_directories(optional INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:include>)
     install(TARGETS optional EXPORT optional-targets)
     install(EXPORT optional-targets DESTINATION lib/cmake/akrzemi1_optional


### PR DESCRIPTION
This change fixes the usage of this library with `add_subdirectory()`.

The public include directory is not `include`, but the root directory. Unfortunately, this was declared wrongly in the `target_include_directories` call. By removing `/include`, the right directory is included when using `target_link_library`.